### PR TITLE
Support Erlang/OTP 21

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,6 +36,6 @@
  [
   {test,
    [
-    {plugins, [rebar_covertool]}
+    {plugins, [covertool]}
    ]}
  ]}.

--- a/src/passage_pd.erl
+++ b/src/passage_pd.erl
@@ -54,6 +54,16 @@
 %%------------------------------------------------------------------------------
 -define(ANCESTORS_KEY, passage_span_ancestors).
 
+-ifdef('OTP_RELEASE').
+%% The 'OTP_RELEASE' macro introduced at OTP-21,
+%% so we can use it for detecting whether the Erlang compiler supports new try/catch syntax or not.
+-define(CAPTURE_STACKTRACE, :__StackTrace).
+-define(GET_STACKTRACE, __StackTrace).
+-else.
+-define(CAPTURE_STACKTRACE, ).
+-define(GET_STACKTRACE, erlang:get_stacktrace()).
+-endif.
+
 %%------------------------------------------------------------------------------
 %% Exported Types
 %%------------------------------------------------------------------------------
@@ -135,8 +145,8 @@ with_span(OperationName, Options, Fun) ->
                 start_span(OperationName, Options),
                 Fun()
             catch
-                Class:Error ->
-                    Stack = erlang:get_stacktrace(),
+                Class:Error ?CAPTURE_STACKTRACE ->
+                    Stack = ?GET_STACKTRACE,
                     log(#{?LOG_FIELD_ERROR_KIND => Class,
                           ?LOG_FIELD_MESSAGE => Error,
                           ?LOG_FIELD_STACK => Stack},

--- a/src/passage_transform.erl
+++ b/src/passage_transform.erl
@@ -361,10 +361,10 @@ make_catch_clauses(_, #state{error_if_exception = false}) ->
 make_catch_clauses(Line, _) ->
     ClassVar = make_var(Line, "__Class"),
     ErrorVar = make_var(Line, "__Error"),
-    GetStrackTrace = make_call_remote(Line, erlang, get_stacktrace, []),
+    {StackTraceVar, GetStrackTrace} = make_stacktrace(Line),
     [
      {clause, Line,
-      [{tuple, Line, [ClassVar, ErrorVar, {var, Line, '_'}]}],
+      [{tuple, Line, [ClassVar, ErrorVar, StackTraceVar]}],
       [],
       [
        make_error_log(
@@ -378,3 +378,21 @@ make_catch_clauses(Line, _) ->
       ]
      }
     ].
+
+-ifdef('OTP_RELEASE').
+
+-spec make_stacktrace(line()) -> {expr_var(), expr_var()}.
+make_stacktrace(Line) ->
+    StackTraceVar = make_var(Line, "__StackTrace"),
+    GetStrackTrace = StackTraceVar,
+    {StackTraceVar, GetStrackTrace}.
+
+-else.
+
+-spec make_stacktrace(line()) -> {expr_var(), expr_call_remote()}.
+make_stacktrace(Line) ->
+    StackTraceVar = {var, Line, '_'},
+    GetStrackTrace = make_call_remote(Line, erlang, get_stacktrace, []),
+    {StackTraceVar, GetStrackTrace}.
+
+-endif.


### PR DESCRIPTION
This changes support Erlang/OTP 21 syntax.

FYI, Here is parsed new syntax and old syntax by `erl_parse:parse_exprs/1`.
```erlang
8> {ok, Tokens, _} = erl_scan:string("_ = try ok catch C:R:S -> {C, R, S} end.").
{ok,[{var,1,'_'},
     {'=',1},
     {'try',1},
     {atom,1,ok},
     {'catch',1},
     {var,1,'C'},
     {':',1},
     {var,1,'R'},
     {':',1},
     {var,1,'S'},
     {'->',1},
     {'{',1},
     {var,1,'C'},
     {',',1},
     {var,1,'R'},
     {',',1},
     {var,1,'S'},
     {'}',1},
     {'end',1},
     {dot,1}],
    1}
9> {ok, [Expr]} = erl_parse:parse_exprs(Tokens).
{ok,[{match,1,
            {var,1,'_'},
            {'try',1,
                   [{atom,1,ok}],
                   [],
                   [{clause,1,
                            [{tuple,1,[{var,1,'C'},{var,1,'R'},{var,1,'S'}]}],
                            [],
                            [{tuple,1,[{var,1,'C'},{var,1,'R'},{var,1,'S'}]}]}],
                   []}}]}
```

```erlang
1> {ok, Tokens, _} = erl_scan:string("_ = try ok catch C:R -> {C, R, erlang:get_stacktrace()} end.").
{ok,[{var,1,'_'},
     {'=',1},
     {'try',1},
     {atom,1,ok},
     {'catch',1},
     {var,1,'C'},
     {':',1},
     {var,1,'R'},
     {'->',1},
     {'{',1},
     {var,1,'C'},
     {',',1},
     {var,1,'R'},
     {',',1},
     {atom,1,erlang},
     {':',1},
     {atom,1,get_stacktrace},
     {'(',1},
     {')',1},
     {'}',1},
     {'end',1},
     {dot,1}],
    1}
2> {ok, [Expr]} = erl_parse:parse_exprs(Tokens).
{ok,[{match,1,
            {var,1,'_'},
            {'try',1,
                   [{atom,1,ok}],
                   [],
                   [{clause,1,
                            [{tuple,1,[{var,1,'C'},{var,1,'R'},{var,1,'_'}]}],
                            [],
                            [{tuple,1,
                                    [{var,1,'C'},{var,1,'R'},{call,1,{remote,...},[]}]}]}],
                   []}}]}
3>
```